### PR TITLE
Suggestion to fix deprecation messages in Symfony 4.3

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace Cethyworks\GooglePlaceAutocompleteBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use App\Kernel;
 
 /**
  * This is the class that validates and merges configuration from your app/config files.
@@ -17,10 +18,10 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('cethyworks_google_place_autocomplete');
+        if (Kernel::VERSION_ID >= 40200) {
+            $treeBuilder = new TreeBuilder('cethyworks_google_place_autocomplete');
 
-        $rootNode
+            $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('google')
                     ->addDefaultsIfNotSet()
@@ -34,6 +35,25 @@ class Configuration implements ConfigurationInterface
                 ->end() // google
             ->end();
         ;
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('cethyworks_google_place_autocomplete');
+
+            $rootNode
+                ->children()
+                    ->arrayNode('google')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('api_key')
+                                ->isRequired()
+                                ->cannotBeEmpty()
+                                ->defaultValue('')
+                            ->end()
+                        ->end()
+                    ->end() // google
+                ->end();
+            ;
+        }
 
         return $treeBuilder;
     }

--- a/src/Form/Extension/GooglePlaceAutocompleteInjectorAwareTypeExtension.php
+++ b/src/Form/Extension/GooglePlaceAutocompleteInjectorAwareTypeExtension.php
@@ -30,12 +30,23 @@ class GooglePlaceAutocompleteInjectorAwareTypeExtension extends AbstractTypeExte
 
     /**
      * Returns the name of the type being extended.
+     * Kept and modified for Symfony < 4.2, its deprecated and replaced by static function below.
      *
      * @return string The name of the type being extended
      */
     public function getExtendedType()
     {
-        return FormType::class;
+        return self::getExtendedTypes()[0];
+    }
+
+    /**
+     * Gets the extended types - not implementing it is deprecated since Symfony 4.2.
+     *
+     * @return array The name of the type being extended
+     */
+    public static function getExtendedTypes()
+    {
+        return [FormType::class];
     }
 
     /**

--- a/src/Resources/assets/twig/complex_google_place_autocomplete_js.html.twig
+++ b/src/Resources/assets/twig/complex_google_place_autocomplete_js.html.twig
@@ -23,5 +23,11 @@
         });
       }
     });
+
+    google.maps.event.addDomListener(userInput, 'keydown', function(event) { 
+      if (event.keyCode === 13) { 
+        event.preventDefault(); 
+      }
+    });
   }
 </script>


### PR DESCRIPTION
The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "cethyworks_google_place_autocomplete" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.

Fixed by 3fee2d0.

Class "Cethyworks\GooglePlaceAutocompleteBundle\Form\Extension\GooglePlaceAutocompleteInjectorAwareTypeExtension" should implement method "static Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes()": Gets the extended types - not implementing it is deprecated since Symfony 4.2.

Not implementing the static getExtendedTypes() method in Cethyworks\GooglePlaceAutocompleteBundle\Form\Extension\GooglePlaceAutocompleteInjectorAwareTypeExtension when implementing the Symfony\Component\Form\FormTypeExtensionInterface is deprecated since Symfony 4.2. The method will be added to the interface in 5.0.

Fixed by 5eb8b10.

I believe this should fix and also working backwards.