### PR TITLE
Add API key provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ Use 2.2 or lower
 ## Install
 
 1\. Composer require
-
+```
     $ composer require cethyworks/google-place-autocomplete-bundle
+```
 
 2\. Register bundles
-
+```php
     // AppKernel.php
     class AppKernel extends Kernel
     {
@@ -31,18 +32,63 @@ Use 2.2 or lower
                 new Cethyworks\GooglePlaceAutocompleteBundle\CethyworksGooglePlaceAutocompleteBundle(),
             ];
             // ...
-
+        }
+    }
+```
 
 ## How to use
 1\. Add (optionally) a `config/packages/cethyworks_google_place_autocomplete.yaml` file with :
-
+```yaml
     cethyworks_google_place_autocomplete:
         google:
             api_key: 'your_api_key'
-
+```
 2\. Use `Cethyworks\GooglePlaceAutocompleteBundle\Form\SimpleGooglePlaceAutocompleteType` into your forms ;
   
 3\. Done !
+
+## Get API key from custom provider
+If you need to get your API key from another way. You can use a custom provider
+
+Example of custom provider with API key stored in database.
+
+```yaml
+    cethyworks_google_place_autocomplete:
+        google:
+            api_key_provider: 'Acme\FooBundle\Provider\BarApiKeyTestProvider'
+```
+
+```php
+namespace Acme\FooBundle\Provider;
+
+use Doctrine\ORM\EntityManager;
+use Cethyworks\GooglePlaceAutocompleteBundle\Provider\ApiKeyProviderInterface;
+
+class BarApiKeyTestProvider implements ApiKeyProviderInterface
+{
+    /** @var EntityManager */
+    protected $em;
+
+    /**
+     * @param EntityManager $em
+     */
+    public function __construct(EntityManager $em)
+    {
+        $this->em = $em;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGoogleApiKey(): string
+    {
+        $bar = $this->em->getRepository('FooBundle:Bar')->findOneBy([
+            'enabled' => true,
+        ]);
+        return $bar->getApiKey();
+    }
+}
+```
 
 
 ## Get more data from the Google Place API

--- a/src/CethyworksGooglePlaceAutocompleteBundle.php
+++ b/src/CethyworksGooglePlaceAutocompleteBundle.php
@@ -2,6 +2,7 @@
 
 namespace Cethyworks\GooglePlaceAutocompleteBundle;
 
+use Cethyworks\GooglePlaceAutocompleteBundle\DependencyInjection\Compiler\ApiKeyProviderCompilerPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\DoctrineOrmMappingsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -13,6 +14,7 @@ class CethyworksGooglePlaceAutocompleteBundle extends Bundle
         parent::build($container);
 
         $this->addRegisterMappingsPass($container);
+        $container->addCompilerPass(new ApiKeyProviderCompilerPass());
     }
 
     /**

--- a/src/Command/GooglePlaceAutocompleteLibraryCommand.php
+++ b/src/Command/GooglePlaceAutocompleteLibraryCommand.php
@@ -3,6 +3,7 @@
 namespace Cethyworks\GooglePlaceAutocompleteBundle\Command;
 
 use Cethyworks\ContentInjectorBundle\Command\TwigCommand;
+use Cethyworks\GooglePlaceAutocompleteBundle\Provider\ApiKeyProviderInterface;
 use Twig_Environment;
 
 class GooglePlaceAutocompleteLibraryCommand extends TwigCommand
@@ -13,12 +14,12 @@ class GooglePlaceAutocompleteLibraryCommand extends TwigCommand
      * GooglePlaceAutocompleteLibraryCommand constructor.
      *
      * @param Twig_Environment $twig
-     * @param string $apiKey
+     * @param ApiKeyProviderInterface $apiKeyProvider
      */
-    public function __construct(Twig_Environment $twig, $apiKey)
+    public function __construct(Twig_Environment $twig, ApiKeyProviderInterface $apiKeyProvider)
     {
         parent::__construct($twig);
-        $this->setGoogleApiKey($apiKey);
+        $this->setGoogleApiKey($apiKeyProvider->getGoogleApiKey());
     }
 
     /**

--- a/src/DependencyInjection/CethyworksGooglePlaceAutocompleteExtension.php
+++ b/src/DependencyInjection/CethyworksGooglePlaceAutocompleteExtension.php
@@ -2,10 +2,10 @@
 
 namespace Cethyworks\GooglePlaceAutocompleteBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration.
@@ -24,6 +24,7 @@ class CethyworksGooglePlaceAutocompleteExtension extends Extension
 
         // setup parameters
         $container->setParameter('cethyworks.google_place_autocomplete.google_api_key', $config['google']['api_key']);
+        $container->setParameter('cethyworks.google_place_autocomplete.google_api_key_provider', $config['google']['api_key_provider']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/src/DependencyInjection/Compiler/ApiKeyProviderCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ApiKeyProviderCompilerPass.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Cethyworks\GooglePlaceAutocompleteBundle\DependencyInjection\Compiler;
+
+use Cethyworks\GooglePlaceAutocompleteBundle\Command\GooglePlaceAutocompleteLibraryCommand;
+use Cethyworks\GooglePlaceAutocompleteBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class ApiKeyProviderCompilerPass
+ *
+ * @package Cethyworks\GooglePlaceAutocompleteBundle\DependencyInjection
+ */
+class ApiKeyProviderCompilerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $configs = $container->getExtensionConfig('cethyworks_google_place_autocomplete');
+        $configuration = new Configuration();
+        $config = $this->processConfiguration($configuration, $configs);
+        $commandDefinition = $container->getDefinition(GooglePlaceAutocompleteLibraryCommand::class);
+        $providerDefinition = $container->getDefinition($config['google']['api_key_provider']);
+        $commandDefinition->setArgument(1, $providerDefinition);
+    }
+
+    /**
+     * @param ConfigurationInterface $configuration
+     * @param array $configs
+     *
+     * @return array
+     */
+    protected function processConfiguration(ConfigurationInterface $configuration, array $configs)
+    {
+        $processor = new Processor();
+
+        return $processor->processConfiguration($configuration, $configs);
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Cethyworks\GooglePlaceAutocompleteBundle\DependencyInjection;
 
+use Cethyworks\GooglePlaceAutocompleteBundle\Provider\DefaultApiKeyProvider;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -25,9 +26,11 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('google')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('api_key')
-                            ->isRequired()
+                        ->scalarNode('api_key_provider')
+                            ->defaultValue(DefaultApiKeyProvider::class)
                             ->cannotBeEmpty()
+                        ->end()
+                        ->scalarNode('api_key')
                             ->defaultValue('')
                         ->end()
                     ->end()

--- a/src/Provider/ApiKeyProviderInterface.php
+++ b/src/Provider/ApiKeyProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Cethyworks\GooglePlaceAutocompleteBundle\Provider;
+
+interface ApiKeyProviderInterface
+{
+    public function getGoogleApiKey();
+}

--- a/src/Provider/DefaultApiKeyProvider.php
+++ b/src/Provider/DefaultApiKeyProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Cethyworks\GooglePlaceAutocompleteBundle\Provider;
+
+class DefaultApiKeyProvider implements ApiKeyProviderInterface
+{
+    /** @var string */
+    protected $apiKey;
+
+    /**
+     * GoogleApiKeyProvider constructor.
+     *
+     * @param string $apiKey
+     */
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGoogleApiKey()
+    {
+        return $this->apiKey;
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,10 +5,14 @@ services:
         tags:
             - { name: twig.extension }
 
+    Cethyworks\GooglePlaceAutocompleteBundle\Provider\DefaultApiKeyProvider:
+        arguments:
+            - "%cethyworks.google_place_autocomplete.google_api_key%"
+
     Cethyworks\GooglePlaceAutocompleteBundle\Command\GooglePlaceAutocompleteLibraryCommand:
         arguments:
             - "@twig"
-            - "%cethyworks.google_place_autocomplete.google_api_key%"
+            - "@Cethyworks\\GooglePlaceAutocompleteBundle\\Provider\\DefaultApiKeyProvider"
 
     Cethyworks\GooglePlaceAutocompleteBundle\Form\Extension\GooglePlaceAutocompleteInjectorAwareTypeExtension:
         arguments:

--- a/tests/Command/GooglePlaceAutocompleteLibraryCommandTest.php
+++ b/tests/Command/GooglePlaceAutocompleteLibraryCommandTest.php
@@ -3,6 +3,7 @@
 namespace Cethyworks\GooglePlaceAutocompleteBundle\Tests\Command;
 
 use Cethyworks\GooglePlaceAutocompleteBundle\Command\GooglePlaceAutocompleteLibraryCommand;
+use Cethyworks\GooglePlaceAutocompleteBundle\Provider\DefaultApiKeyProvider;
 use PHPUnit\Framework\TestCase;
 
 class GooglePlaceAutocompleteLibraryCommandTest extends TestCase
@@ -13,8 +14,10 @@ class GooglePlaceAutocompleteLibraryCommandTest extends TestCase
         $twig->expects($this->once())->method('render')->with(
             '@CethyworksGooglePlaceAutocompleteBundle/google_place_autocomplete_library.html.twig',
             ['google_api_key' => 'foobar' ]);
+        $provider = $this->getMockBuilder(DefaultApiKeyProvider::class)->disableOriginalConstructor()->getMock();
+        $provider->expects($this->once())->method('getGoogleApiKey')->willReturn('foobar');
 
-        $command = new GooglePlaceAutocompleteLibraryCommand($twig, 'foobar');
+        $command = new GooglePlaceAutocompleteLibraryCommand($twig, $provider);
         $command->setGoogleApiKey('foobar');
         $command();
     }


### PR DESCRIPTION
Hi
I need to store API Key in database, so I add API Key provider feature.
You can now create a custom API Key Provider to get your key from your own service. There is no BC break, the traditional `cethyworks_google_place_autocomplete.google.api_key` config works.

I update the README to explain how to use it with an example.