### PR TITLE
Fix: TreeBuilder Constructor for Symfony 5.1

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,7 +18,7 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder( 'cethyworks_google_place_autocomplete' );
-        $rootNode = $treeBuilder;
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -17,8 +17,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('cethyworks_google_place_autocomplete');
+        $treeBuilder = new TreeBuilder( 'cethyworks_google_place_autocomplete' );
+        $rootNode = $treeBuilder;
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fix #12 

Modification of treeBuilder for Symfony 5.1 remove ->root() and replace on __construct of TreeBuilder